### PR TITLE
Make the amount of scrollback configurable

### DIFF
--- a/lib/loaf/__init__.py
+++ b/lib/loaf/__init__.py
@@ -64,11 +64,12 @@ def main():
     loop = asyncio.get_event_loop()
     widget = loop.run_until_complete(run(args.config))
 
-    urwid.MainLoop(widget, [
+    widget.main_loop = urwid.MainLoop(widget, [
         ('selected', 'default, standout', 'default'),
         ('username', 'default, bold', 'default'),
         ('timestamp', 'default, underline', 'default')
-    ], event_loop=urwid.AsyncioEventLoop(loop=loop)).run()
+    ], event_loop=urwid.AsyncioEventLoop(loop=loop))
+    widget.main_loop.run()
 
 
 if __name__ == '__main__':

--- a/lib/loaf/__init__.py
+++ b/lib/loaf/__init__.py
@@ -36,7 +36,8 @@ async def run(config):
         team = Team(
             team_id, team, User(user_id, user),
             web_api=client, rtm_api=rtm_client,
-            alias=team_config.get('alias', None)
+            alias=team_config.get('alias', None),
+            duration=int(team_config.get('history_weeks', 1))
         )
         await asyncio.gather(team.load_converstions(), team.load_users())
 

--- a/lib/loaf/__init__.py
+++ b/lib/loaf/__init__.py
@@ -67,7 +67,9 @@ def main():
     widget.main_loop = urwid.MainLoop(widget, [
         ('selected', 'default, standout', 'default'),
         ('username', 'default, bold', 'default'),
-        ('timestamp', 'default, underline', 'default')
+        ('timestamp', 'default, underline', 'default'),
+        ('normal', 'default', 'default'),
+        ('reply', 'yellow', 'default')
     ], event_loop=urwid.AsyncioEventLoop(loop=loop))
     widget.main_loop.run()
 

--- a/lib/loaf/__init__.py
+++ b/lib/loaf/__init__.py
@@ -1,9 +1,11 @@
 import argparse
 import asyncio
 from pprint import pprint
+from xdg.BaseDirectory import xdg_config_home
 import itertools
 import json
 import operator
+import os
 
 import urwid
 
@@ -54,7 +56,7 @@ def main():
     parser.add_argument(
         '--config', '-c',
         metavar='CONFIG',
-        default='config.json',
+        default=os.path.join(xdg_config_home, 'loaf', 'config.json'),
         type=JSONType
     )
     args = parser.parse_args()

--- a/lib/loaf/__init__.py
+++ b/lib/loaf/__init__.py
@@ -37,7 +37,8 @@ async def run(config):
             team_id, team, User(user_id, user),
             web_api=client, rtm_api=rtm_client,
             alias=team_config.get('alias', None),
-            duration=int(team_config.get('history_weeks', 1))
+            duration=int(team_config.get('history_weeks', 1)),
+            sync_dir=team_config.get('sync_dir', None)
         )
         await asyncio.gather(team.load_converstions(), team.load_users())
 

--- a/lib/loaf/models.py
+++ b/lib/loaf/models.py
@@ -176,6 +176,8 @@ class Team(EventEmitter):
                 conversation_name = conversation['name']
             except KeyError:
                 conversation_name = "Unknown"
+                if conversation['is_im']:
+                    conversation_name = "IM: " + self.users[conversation['user']].name
             self.add_conversation(Conversation(
                 self, conversation['id'], conversation_name
             ))

--- a/lib/loaf/models.py
+++ b/lib/loaf/models.py
@@ -94,15 +94,12 @@ class Conversation(EventEmitter):
         messages += new_messages
         for message in messages:
             self.add_message(message)
-            try:
-                if message['reply_count'] > 0:
-                    async for reply in self.team.web_api.conversations.replies(
-                        self.id,
-                        message['ts']
-                    ):
-                        self.add_message(reply)
-            except:
-                pass
+            if 'reply_count' in message:
+                async for reply in self.team.web_api.conversations.replies(
+                    self.id,
+                    message['ts']
+                ):
+                    self.add_message(reply)
 
     @reify
     def messages(self):

--- a/lib/loaf/models.py
+++ b/lib/loaf/models.py
@@ -172,8 +172,12 @@ class Team(EventEmitter):
 
     async def load_converstions(self):
         async for conversation in self.web_api.conversations.list():
+            try:
+                conversation_name = conversation['name']
+            except KeyError:
+                conversation_name = "Unknown"
             self.add_conversation(Conversation(
-                self, conversation['id'], conversation['name']
+                self, conversation['id'], conversation_name
             ))
 
     async def load_users(self):

--- a/lib/loaf/models.py
+++ b/lib/loaf/models.py
@@ -109,11 +109,6 @@ class Conversation(EventEmitter):
             # TODO: Error handling here
             # Show the user a message or something
             pass
-        else:
-            self.add_message({
-                'user': self.team.me.id,
-                **response
-            })
 
 
 class Team(EventEmitter):

--- a/lib/loaf/models.py
+++ b/lib/loaf/models.py
@@ -34,10 +34,12 @@ class Conversation(EventEmitter):
     def add_message(self, message):
         try:
             user = message['user']
-        except KeyError:
-            user = User(None, message['username'])
-        else:
             user = self.team.users[user]
+        except KeyError:
+            try:
+                user = User(None, message['username'])
+            except KeyError:
+                user = User(None, "Unknown")
 
         message = Message(
             message['ts'],

--- a/lib/loaf/models.py
+++ b/lib/loaf/models.py
@@ -46,7 +46,7 @@ class Conversation(EventEmitter):
         self.emit('message', self, message)
 
     async def load_messages(self):
-        oldest = (datetime.now() - timedelta(weeks=1)).timestamp()
+        oldest = (datetime.now() - timedelta(weeks=self.team.duration)).timestamp()
 
         messages = []
         async for message in self.team.web_api.conversations.history(
@@ -87,12 +87,13 @@ class Team(EventEmitter):
     def __init__(
             self, id, name, me, *,
             web_api, rtm_api,
-            alias=None
+            alias=None, duration=1
         ):
         self.id = id
         self.name = name
         self.me = me
         self.alias = alias
+        self.duration = duration
 
         self.web_api = web_api
         self.rtm_api = rtm_api

--- a/lib/loaf/slack_api/web_client/conversations.py
+++ b/lib/loaf/slack_api/web_client/conversations.py
@@ -2,7 +2,7 @@ class Conversations:
     def __init__(self, client):
         self.client = client
 
-    async def list(self, exclude_archived=None, limit=None, types=None):
+    async def list(self, exclude_archived=None, limit=None, types='public_channel,private_channel,mpim,im'):
         if isinstance(types, (list, tuple)):
             types = ', '.join(types)
 

--- a/lib/loaf/slack_api/web_client/conversations.py
+++ b/lib/loaf/slack_api/web_client/conversations.py
@@ -34,7 +34,7 @@ class Conversations:
 
     async def replies(
         self, channel, ts,
-        cursor=None, include_all_metadata=None, inclusive=None, latest=None, limit=None, oldest=None
+        inclusive=None, latest=None, limit=None, oldest=None
     ):
         async for response in self.client.paginate_api_call(
             'GET', 'conversations.replies', params=dict(

--- a/lib/loaf/slack_api/web_client/conversations.py
+++ b/lib/loaf/slack_api/web_client/conversations.py
@@ -32,6 +32,23 @@ class Conversations:
             for message in response['messages']:
                 yield message
 
+    async def replies(
+        self, channel, ts,
+        cursor=None, include_all_metadata=None, inclusive=None, latest=None, limit=None, oldest=None
+    ):
+        async for response in self.client.paginate_api_call(
+            'GET', 'conversations.replies', params=dict(
+                channel=channel,
+                ts=ts,
+                inclusive=inclusive,
+                latest=latest,
+                limit=limit,
+                oldest=oldest
+            )
+        ):
+            for message in response['messages']:
+                yield message
+
     async def info(self, channel, include_locale=None):
         response = await self.client.api_call(
             'GET', 'conversations.info', params=dict(
@@ -62,8 +79,6 @@ class Conversations:
     def open(self): pass
 
     def rename(self): pass
-
-    def replies(self): pass
 
     def set_purpose(self): pass
 

--- a/lib/loaf/ui/__init__.py
+++ b/lib/loaf/ui/__init__.py
@@ -7,12 +7,15 @@ from .treelist.nodes import TeamOverviewNode
 
 
 class MessageWidget(urwid.WidgetWrap):
-    def __init__(self, ts, user, message):
+    def __init__(self, ts, user, message, is_reply):
+        descriptor = 'normal'
+        if is_reply:
+            descriptor = 'reply'
         super().__init__(urwid.AttrMap(
             urwid.Columns([
                 ('weight', 10, urwid.Text(('timestamp', str(datetime.fromtimestamp(float(ts) // 1))))),
                 ('weight', 10, urwid.Text(('username', user.name))),
-                ('weight', 80, urwid.Text(message))
+                ('weight', 80, urwid.Text((descriptor, message)))
             ], dividechars=2),
             None, 'selected'
         ))
@@ -49,7 +52,7 @@ class LoafWidget(urwid.WidgetWrap):
                 f'#{team.active_conversation.name}'
             )
             self.messages.body[:] = [
-                MessageWidget(msg.ts, msg.user, msg.message)
+                MessageWidget(msg.ts, msg.user, msg.message, msg.is_reply)
                 for msg in team.active_conversation.messages
             ]
 
@@ -63,7 +66,7 @@ class LoafWidget(urwid.WidgetWrap):
                 return
 
             self.messages.body.append(
-                MessageWidget(message.ts, message.user, message.message)
+                MessageWidget(message.ts, message.user, message.message, message.is_reply)
             )
 
             # For now just snap the messages to the bottom of the

--- a/lib/loaf/ui/__init__.py
+++ b/lib/loaf/ui/__init__.py
@@ -31,6 +31,7 @@ class MessageEdit(urwid.Edit):
 
 class LoafWidget(urwid.WidgetWrap):
     def __init__(self, team_overview):
+        self.main_loop = None
         self.team_overview = team_overview
 
         team_overview.on('teams_changed', lambda: urwid.emit_signal(
@@ -68,6 +69,8 @@ class LoafWidget(urwid.WidgetWrap):
             # For now just snap the messages to the bottom of the
             # listbox
             self.messages.set_focus(len(self.messages.body) - 1)
+            if self.main_loop != None:
+                asyncio.get_event_loop().call_soon(self.main_loop.draw_screen)
 
         super().__init__(self.widget)
 


### PR DESCRIPTION
People with a less active slack team might not want to check it every
week. Especially one that is used with a proof-of-concept client. This
keeps the one week default but allows the user to change it.

Signed-off-by: Connor Behan <connor.behan@gmail.com>